### PR TITLE
Upped figwheel-main to 0.2.3 to fix Figwheel Jetty conflicts

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
   org.clojure/clojurescript {:mvn/version "1.10.439"}
   hodur/engine              {:mvn/version "0.1.2"}
   datascript                {:mvn/version "0.16.7"}
-  com.bhauman/figwheel-main {:mvn/version "0.1.9"}}
+  com.bhauman/figwheel-main {:mvn/version "0.2.3"}}
 
  :aliases
  {:dev


### PR DESCRIPTION
See https://figwheel.org/docs/jetty_conflicts.html

This fixes https://github.com/hodur-org/hodur-visualizer-schema/issues/8